### PR TITLE
Fix raw string literal and add better ip regex

### DIFF
--- a/commonregex.py
+++ b/commonregex.py
@@ -3,75 +3,75 @@ import re
 
 class CommonRegex:
 
-  def __init__(self, text=""):
-    self.text = text
+    def __init__(self, text=""):
+        self.text = text
 
-    if text:
-      self.dates    = self.dates()
-      self.times    = self.times()
-      self.phones   = self.phones()
-      self.links    = self.links()
-      self.emails   = self.emails()
-      self.ip       = self.ip()
+        if text:
+            self.dates    = self.dates()
+            self.times    = self.times()
+            self.phones   = self.phones()
+            self.links    = self.links()
+            self.emails   = self.emails()
+            self.ip       = self.ip()
 
-  def _opt(self, regex):
-    return ur'(?:' + regex + ur')?'
+    def _opt(self, regex):
+        return u'(?:' + regex + u')?'
 
-  def _group(self, regex):
-    return ur'(?:' + regex + ')'
+    def _group(self, regex):
+        return u'(?:' + regex + ')'
 
-  def _any(self, *regexes):
-    return ur'|'.join(regexes)
+    def _any(self, *regexes):
+        return u'|'.join(regexes)
 
-  def _strip(fn, *args, **kwargs):
-    def new_fn(*args, **kwargs):
-      return [x.strip() for x in fn(*args, **kwargs)]
-    return new_fn
+    def _strip(fn, *args, **kwargs):
+        def new_fn(*args, **kwargs):
+          return [x.strip() for x in fn(*args, **kwargs)]
+        return new_fn
 
-  @_strip
-  def dates(self, text=None):
-    text = text or self.text
-    month_regex = ur'(?:jan\.?|january|feb\.?|february|mar\.?|march|apr\.?|april|may|jun\.?|june|jul\.?|july|aug\.?|august|sep\.?|september|oct\.?|october|nov\.?|november|dec\.?|december)'
-    day_regex = ur'(?<!\:)(?<!\:\d)[0-3]?\d(?:st|nd|rd|th)?'
-    year_regex = ur'\d{4}'
-    date_regex = self._group(self._any(day_regex + ur'\s+(?:of\s+)?' + month_regex, month_regex + ur'\s+' + day_regex)) + ur'(?:\,)?\s*' + self._opt(year_regex) + ur'|[0-3]?\d[-/][0-3]?\d[-/]\d{2,4}'
-    return re.findall(date_regex, text, re.IGNORECASE)
+    @_strip
+    def dates(self, text=None):
+        text = text or self.text
+        month_regex = u'(?:jan\.?|january|feb\.?|february|mar\.?|march|apr\.?|april|may|jun\.?|june|jul\.?|july|aug\.?|august|sep\.?|september|oct\.?|october|nov\.?|november|dec\.?|december)'
+        day_regex = u'(?<!\:)(?<!\:\d)[0-3]?\d(?:st|nd|rd|th)?'
+        year_regex = u'\d{4}'
+        date_regex = self._group(self._any(day_regex + u'\s+(?:of\s+)?' + month_regex, month_regex + u'\s+' + day_regex)) + u'(?:\,)?\s*' + self._opt(year_regex) + u'|[0-3]?\d[-/][0-3]?\d[-/]\d{2,4}'
+        return re.findall(date_regex, text, re.IGNORECASE)
 
-  @_strip
-  def times(self, text=None):
-    text = text or self.text
-    time_regex = ur'\d{1,2}:\d{2} ?(?:[ap]\.?m\.?)?|\d[ap]\.?m\.?'
-    return re.findall(time_regex, text, re.IGNORECASE)
+    @_strip
+    def times(self, text=None):
+        text = text or self.text
+        time_regex = u'\d{1,2}:\d{2} ?(?:[ap]\.?m\.?)?|\d[ap]\.?m\.?'
+        return re.findall(time_regex, text, re.IGNORECASE)
 
-  @_strip
-  def phones(self, text=None):
-    text = text or self.text
-    phone_regex = ur'(\d?\W*(?:\(?\d{3}\)?\W*)?\d{3}\W*\d{4})'
-    return re.findall(phone_regex, text)
+    @_strip
+    def phones(self, text=None):
+        text = text or self.text
+        phone_regex = u'(\d?\W*(?:\(?\d{3}\)?\W*)?\d{3}\W*\d{4})'
+        return re.findall(phone_regex, text)
 
-  @_strip
-  def links(self, text=None):
-    text = text or self.text
-    link_regex = ur'(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\))+(?:\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?\xab\xbb\u201c\u201d\u2018\u2019]))'
-    return re.findall(link_regex, text, re.IGNORECASE)
+    @_strip
+    def links(self, text=None):
+        text = text or self.text
+        link_regex = u'(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\))+(?:\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?\xab\xbb\u201c\u201d\u2018\u2019]))'
+        return re.findall(link_regex, text, re.IGNORECASE)
 
-  @_strip
-  def emails(self, text=None):
-    text = text or self.text
-    email_regex = ur"([a-z0-9!#$%&'*+\/=?^_`{|}~-]+@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)"
-    return re.findall(email_regex, text, re.IGNORECASE)
+    @_strip
+    def emails(self, text=None):
+        text = text or self.text
+        email_regex = u"([a-z0-9!#$%&'*+\/=?^_`{|}~-]+@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)"
+        return re.findall(email_regex, text, re.IGNORECASE)
 
-  @_strip 
-  def ip(self, text=None):
-    text = text or self.text
-    ip_regex = ur'(?<!\d)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
-    return re.findall(ip_regex, text)
+    @_strip
+    def ip(self, text=None):
+        text = text or self.text
+        ip_regex = u'(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)'
+        return re.findall(ip_regex, text)
 
 if __name__ == "__main__":
-  parse = CommonRegex("8:00 5:00AM Jan 9th 2012 8/23/12 www.google.com http://hotmail.com (520) 820 7123, 1-230-241-2422 john_smith@gmail.com 127.0.0.1")
-  print parse.dates
-  print parse.times
-  print parse.phones
-  print parse.links
-  print parse.emails
-  print parse.ip
+    parse = CommonRegex("8:00 5:00AM Jan 9th 2012 8/23/12 www.google.com http://hotmail.com (520) 820 7123, 1-230-241-2422 john_smith@gmail.com 127.0.0.1")
+    print(parse.dates)
+    print(parse.times)
+    print(parse.phones)
+    print(parse.links)
+    print(parse.emails)
+    print(parse.ip)


### PR DESCRIPTION
Hello, madisonmay!
I'm fix spaces (1 Tab = 2 space, not 4 space).
Add better ip regex.
And fix raw string literal, because on my system this led to some error, like that:
wimbo@wimbo-hp:~/github/CommonRegex$ python3 commonregex.py
  File "commonregex.py", line 18
    return (ur'(?:' + regex + ur')?')
                  ^
SyntaxError: invalid syntax

But after remove i'm test on Python 2.7.4 and 3.3.1:
wimbo@wimbo-hp:~/github/CommonRegex$ python2 --version
Python 2.7.4
wimbo@wimbo-hp:~/github/CommonRegex$ python2 commonregex.py
['Jan 9th 2012', '8/23/12']
['8:00', '5:00AM']
['(520) 820 7123', '1-230-241-2422']
[]
['john_smith@gmail.com']
['127.0.0.1']
wimbo@wimbo-hp:~/github/CommonRegex$ python3 --version
Python 3.3.1
wimbo@wimbo-hp:~/github/CommonRegex$ python3 commonregex.py
['Jan 9th 2012', '8/23/12']
['8:00', '5:00AM']
['(520) 820 7123', '1-230-241-2422']
[]
['john_smith@gmail.com']
['127.0.0.1'

Looks right, What do you think?

Sorry my bad english.
