### PR TITLE
Add regex for hexColor (rgb and rgba)

### DIFF
--- a/commonregex.py
+++ b/commonregex.py
@@ -14,6 +14,7 @@ class CommonRegex:
             self.emails   = self.emails()
             self.ip       = self.ip()
             self.money    = self.money()
+            self.hexColor = self.hexColor()
 
     def _opt(self, regex):
         return u'(?:' + regex + u')?'
@@ -74,8 +75,14 @@ class CommonRegex:
         money_regexp = u"\$\s?[+-]?[0-9]{1,3}(?:,?[0-9])*(?:\.[0-9]{1,2})?"
         return re.findall(money_regexp, text)
 
+    @_strip
+    def hexColor(self, text=None):
+        text = text or self.text
+        hexColor_regex = u'(#(?:[0-9a-fA-F]{8})|#(?:[0-9a-fA-F]{3}){1,2})\\b'
+        return re.findall(hexColor_regex, text)
+
 if __name__ == "__main__":
-    parse = CommonRegex("8:00 5:00AM Jan 9th 2012 8/23/12 www.google.com $4891.75 http://hotmail.com (520) 820 7123, 1-230-241-2422 john_smith@gmail.com 127.0.0.1")
+    parse = CommonRegex("8:00 5:00AM Jan 9th 2012 8/23/12 www.google.com $4891.75 http://hotmail.com (520) 820 7123, 1-230-241-2422 john_smith@gmail.com 127.0.0.1 #e9be4fff ")
     print(parse.dates)
     print(parse.times)
     print(parse.phones)
@@ -83,3 +90,4 @@ if __name__ == "__main__":
     print(parse.emails)
     print(parse.ip)
     print(parse.money)
+    print(parse.hexColor)


### PR DESCRIPTION
Hello, some more feature for CommoRegex.
Now this module can find rgb and rgba hex color
What do you think?
Idea comes from JS Port: https://github.com/talyssonoc/CommonRegexJS
